### PR TITLE
Add projected completion date for epics

### DIFF
--- a/lib/tracker_api/resources/epic.rb
+++ b/lib/tracker_api/resources/epic.rb
@@ -18,6 +18,7 @@ module TrackerApi
       attribute :project_id, Integer
       attribute :updated_at, DateTime
       attribute :completed_at, DateTime
+      attribute :projected_completion, DateTime
       attribute :url, String
 
       class UpdateRepresenter < Representable::Decorator


### PR DESCRIPTION
### Usage
```ruby
client = TrackerApi::Client.new(token: token)
project = client.project(project_id)
epics = project.epics(fields: ":default,followers,projected_completion")
projected_completion = epics.first.projected_completion
```

### Documentation
https://www.pivotaltracker.com/help/api/rest/v5#epic_resource

### Notes
I believe there may be an issue with the virtus dependency (v2.0.0) where the `attributes` method now breaks:
<img width="430" alt="Screen Shot 2022-07-20 at 2 20 39 PM" src="https://user-images.githubusercontent.com/21958701/180084244-41422205-961c-4f8b-a995-94e323a1d0c1.png">
I did find that method to come directly from virtus, and on previous major versions (e.g. v1.0.5), the attributes method is not broken. I'm trying to track down where that might've gone wrong, but given that virtus is sunsetted, I'm not sure it'll get any updates if I open an issue. Besides, we don't typically fetch the entire attribute set from these resources, usually just the ones we need.